### PR TITLE
Update index.md

### DIFF
--- a/content/brukeropplevelse-og-datadeling/team/products-and-devops/platform/index.md
+++ b/content/brukeropplevelse-og-datadeling/team/products-and-devops/platform/index.md
@@ -1,6 +1,6 @@
 ---
-title: Team - Altinn Core (Altinn 3)
-ingress: Team Altinn Core har hovedansvar for å utvikle felleskomponenter som skal understøtte ulike produkter i Altinn 3 samt drift/forvaltning av infrastruktur.
+title: Altinn core (Altinn 3)
+ingress: Team Altinn core har hovedansvaret for å utvikle felleskomponenter som støtter ulike produkter i Altinn 3, og drifter/forvalter infrastrukturen.
 
 navigation_link:
   title: Produkteier


### PR DESCRIPTION
Endret ingressen slik at den samsvarer med de andre team-kortene (uten Team -  foran navnet i overskriften). Navnet følger britisk engelsk skrivemåte som er det Digdir retter seg etter. Det vil si at vi skriver Altinn core med liten c, mens vi på amerikansk ville skrevet med stor C.