### PR TITLE
Update index.md

### DIFF
--- a/content/brukeropplevelse-og-datadeling/seksjoner/index.md
+++ b/content/brukeropplevelse-og-datadeling/seksjoner/index.md
@@ -6,8 +6,10 @@ ingress: |
   - Brukeropplevelse (BBO) 
   - Utvikling (BUT) 
   - Plattform og styring (BPS) 
-  - Brukerstøtte og service (BBS) 
-  Seksjonslederne har ansvaret for å bygge opp og organisere fagavdelingene, lede personalet og generelt styre arbeidet i seksjonen.
+  - Brukerstøtte og service (BBS)
+<p>
+Seksjonene i BOD er først og fremst et personal-hjem for medarbeidere fra felles kompetanseområder. Seksjonene avgir ressurser(kompetanse) til leveranse-områder i og utenfor BOD som f.eks. til Digdir sine produktgrupper, prosjekter og andre små og store oppdrag/tiltak. Seksjonslederne har ansvar for å bygge opp, organisere og selvstendig-gjøre fagmiljøene på best mulig måte. 
+</p>
 
 # SEO
 description:


### PR DESCRIPTION
oppdatert avsnitt
Seksjonene i BOD er først og fremst et personal-hjem for medarbeidere fra felles kompetanseområder. Seksjonene avgir ressurser(kompetanse) til leveranse-områder i og utenfor BOD som f.eks. til Digdir sine produktgrupper, prosjekter og andre små og store oppdrag/tiltak. Seksjonslederne har ansvar for å bygge opp, organisere og selvstendig-gjøre fagmiljøene på best mulig måte. 
