### PR TITLE
Oppdatert roller i teamet

### DIFF
--- a/content/teams/okr/index.md
+++ b/content/teams/okr/index.md
@@ -15,14 +15,13 @@ tags:
 ---
 
 {{< team/members title="Medlemmer i teamet" slack_url="https://altinndevops.slack.com/archives/C06GSNENWHM" slack_url_text="Slackkanal for teamet">}}
-{{< team/github-profile url="https://avatars.githubusercontent.com/u/50205992?v=4" name="Hanne Lauritsen" role="Scrum master, OKR Ambassadør, Fast,  Oslo" >}}
-{{< team/github-profile url="https://avatars.githubusercontent.com/u/56063468?v=4" name="Anne Risbakk" role="Scrum master, OKR Ambassadør, fast, Brønnøysund" >}}
+{{< team/github-profile url="https://avatars.githubusercontent.com/u/39302088?v=4" name="Nathalie Froissart" role="Scrum master, OKR Ambassadør, Fast,  Oslo" >}}
+{{< team/github-profile url="https://avatars.githubusercontent.com/u/97237741?v=4" name="Arild Hansten " role="Scrum Master, OKR Ambassadør, Fast, Brønnøysund">}}
 {{< team/github-profile url="https://avatars.githubusercontent.com/u/139115317?v=4" name="Siri-Anna Zahl Kristiansen" role="Scrum master, OKR Ambassadør, fast, Brønnøysund" >}}
 {{< team/github-profile url="https://avatars.githubusercontent.com/u/131167427?v=4" name="Vilde Aga Stixrud" role="Scrum master, OKR Ambassadør, Fast, Brønnøysund" >}}
 {{< team/github-profile url="https://avatars.githubusercontent.com/u/65394379?v=4" name="Tony Grimstad" role="Skjemautvikler, OKR Ambassadør, Fast, Brønnøysund" >}}
 {{< team/github-profile url="https://avatars.githubusercontent.com/u/35563205?v=4" name="Frank-Robert Sveinsbø" role="Porteføljestyrer, OKR Ambassadør, Fast, Oslo" >}}
 {{< team/github-profile url="https://avatars.githubusercontent.com/u/94651380?v=4" name="Lars Göran Andersson " role="Faggruppe Leverandørstyring, OKR Ambassadør, Fast, Brønnøysund">}}
-{{< team/github-profile url="https://avatars.githubusercontent.com/u/97237741?v=4" name="Arild Hansten " role="Fagruppe Risiko, OKR Ambassadør, Fast, Brønnøysund">}}
 {{< team/github-profile url="https://avatars.githubusercontent.com/u/32162632?v=4" name="Sigurd Sæther Sørensen" role="Design Lead, OR Ambassadør, Fast, Oslo">}}
 {{< /team/members >}}
 


### PR DESCRIPTION
Har tatt bort Hanne Lauritsen og Anne Risbakk da de ikke er en del av teamet. Lagt inn Nathalie Froissart som Scrum-master og endret tittel på Arild Hansteen til Scrum-master