### PR TITLE
resources.ToCSS deprecated

### DIFF
--- a/layouts/brukeropplevelse-og-datadeling/rapportering/single.html
+++ b/layouts/brukeropplevelse-og-datadeling/rapportering/single.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
   {{ $sass := resources.Get "sass/rapportering.scss" }}
-  {{ $style := $sass | resources.ToCSS }}
+  {{ $style := $sass | css.Sass }}
   <link rel="stylesheet" href="{{ $style.RelPermalink }}" />
 
 

--- a/layouts/produktgrupper/single_pg.html
+++ b/layouts/produktgrupper/single_pg.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
   {{ $sass := resources.Get "sass/team.scss" }}
-  {{ $style := $sass | resources.ToCSS }}
+  {{ $style := $sass | css.Sass }}
   <link rel="stylesheet" href="{{ $style.RelPermalink }}" />
   {{ with .Page }}
     <div class="component" style="background-color: #faeec2">


### PR DESCRIPTION
Use `css.Sass` to avoid this warning

```shell
WARN  deprecated: resources.ToCSS was deprecated in Hugo v0.128.0 and will be removed in a future release. Use css.Sass instead.
```