### PR TITLE
Add content to team-cases page according to V1 wireframes

### DIFF
--- a/content/produktutviklingsmodell/flyt/portfolio/_index.md
+++ b/content/produktutviklingsmodell/flyt/portfolio/_index.md
@@ -39,4 +39,4 @@ Etter å ha vært gjennom konsept- og planleggingsfasen har du fått beskrevet h
 
 Tiltaket fordeles deretter til produktgruppen, teamet / teamene eller arbeiedsgruppen som skal gjennomføre arbeidet.
 
-[Gå til implementering](https://www.baksia.digdir.no/produktutviklingsmodell/flyt#implementering)
+[Gå til implementering](../../flyt#implementering)

--- a/content/produktutviklingsmodell/flyt/produktgruppe/_index.md
+++ b/content/produktutviklingsmodell/flyt/produktgruppe/_index.md
@@ -32,4 +32,4 @@ Per i dag finnes det ingen formell og delt prosess for hvordan produktgruppelede
 
 Det er opp til produktgruppeleder å prioritere og planlegge implementeringen av ideen sammen med teamene i gruppen.  
   
-[Gå til implementering](https://baksia.digdir.no/produktutviklingsmodell/flyt#implementering)
+[Gå til implementering](../../flyt#implementering)

--- a/content/produktutviklingsmodell/flyt/team/_index.md
+++ b/content/produktutviklingsmodell/flyt/team/_index.md
@@ -31,6 +31,6 @@ Hvis du er usikker på hvilket team du bør ta kontakt med så kan du spør i **
 
 Etter at du har opprettet issuen kan du trykke på subscribe nede til høyre (i github) for å bli varslet når noe skjer (se bilde under til venstre). Det kan også være kjekt å ta vare på tallet bak tittelen. Dette er en unik id for issuen din som du kan henvise til senere (se bilde under til høyre).  
 
-![Et bilde som viser subscribe funksjonen i github og hvor det går an å finne den unike IDen til issuet](/images/folg-fremgangen-github.svg).  
+![Et bilde som viser subscribe funksjonen i github og hvor det går an å finne den unike IDen til issuet](/images/folg-fremgangen-github.png).  
 
 [Gå til implementering](https://baksia.digdir.no/produktutviklingsmodell/flyt#implementering)

--- a/content/produktutviklingsmodell/flyt/team/_index.md
+++ b/content/produktutviklingsmodell/flyt/team/_index.md
@@ -33,4 +33,4 @@ Etter at du har opprettet issuen kan du trykke på subscribe nede til høyre (i 
 
 ![Et bilde som viser subscribe funksjonen i github og hvor det går an å finne den unike IDen til issuet](/images/folg-fremgangen-github.svg).  
 
-[Gå til implementering](/produktutviklingsmodell/flyt#implementering)
+[Gå til implementering](https://baksia.digdir.no/produktutviklingsmodell/flyt#implementering)

--- a/content/produktutviklingsmodell/flyt/team/_index.md
+++ b/content/produktutviklingsmodell/flyt/team/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Teamsaker
-ingress: Denne siden forklarer produkt-teamene sin rolle i flyten for produktutvikling i Digdir.
-bannerimage: /images/team-flow.webp
+ingress: Produkt-teamene sin rolle i flyten for produktutvikling i Digdir.
 weight: 30
 
 navigation_link:
@@ -9,15 +8,29 @@ navigation_link:
 ---
 
 
+## Bør jeg ta direkte kontakt med teamet?
+Teamene arbeider kontinuerlig med å få en balansegang mellom å fikse feil og utbedre produktet, levere i henhold til strategier og program nye Altinn samt å følge egen produktvisjon.  
+
+Dersom ideen din kan løses av ett produktteam uten at det trengs ekstra midler og ressurser så kan produktteamet selv hjelpe deg med å få ideen gjennomført.
+
+[//]: # (Card section skal ligge her)
+[//]: # (Innhold til Porteføljesaker card: "Når du trenger forankring hos ledelsen og ideen tar 6+ måneder å gjennomføre")
+[//]: # (Innhold til Produktgruppesaker card: "Når ideen må løses på tvers av flere team uten ekstra midler og ressurser")
+[//]: # (Innhold til Støtteordninger card: "Medfinansiering og Stimulab er gode alternativer til finansiering" - link til https://www.digdir.no/finansiering/finansiering/702)
+
+
 ## Opprett en issue i teamet sin backlog
+Hvem som helst kan komme med innspill og ønsker til teamene. Dette gjør du ved å opprette en ny issue i Github (du trenger en [github bruker](https://github.com/signup)).  
 
-Hvem som helst kan komme med innspill og ønsker til teamene.
-Dette gjør du ved å opprette en ny issue i Github (du trenger en [github bruker](https://github.com/signup)).
-
-Hvis du er usikker på hvilket team du bør ta kontakt med så kan du spør i [#general](https://altinn.slack.com/archives/CCQEQKGJD) kanalen på Slack eller noen du møter i gangen.
-
-## Implementering av tiltaket
-
-Når teamet har anledning til å prioritere oppgaven så begynner de å beskrive problemet og løsningen på et overordnet teknisk nivå. Etter det bryter de oppgaven ned i mindre tasks som de fordeler seg i mellom for å løse oppgaven.
+Hvis du er usikker på hvilket team du bør ta kontakt med så kan du spør i **[#general](https://altinn.slack.com/archives/CCQEQKGJD)** kanalen på Slack eller noen du møter i gangen.
 
 [Gå til team oversikten](/teams/)
+
+
+## Følg fremgangen
+
+Etter at du har opprettet issuen kan du trykke på subscribe nede til høyre (i github) for å bli varslet når noe skjer (se bilde under til venstre). Det kan også være kjekt å ta vare på tallet bak tittelen. Dette er en unik id for issuen din som du kan henvise til senere (se bilde under til høyre).  
+
+![Et bilde som viser subscribe funksjonen i github og hvor det går an å finne den unike IDen til issuet](/images/folg-fremgangen-github.svg).  
+
+[Gå til implementering](/produktutviklingsmodell/flyt#implementering)

--- a/content/produktutviklingsmodell/flyt/team/_index.md
+++ b/content/produktutviklingsmodell/flyt/team/_index.md
@@ -13,11 +13,7 @@ Teamene arbeider kontinuerlig med å få en balansegang mellom å fikse feil og 
 
 Dersom ideen din kan løses av ett produktteam uten at det trengs ekstra midler og ressurser så kan produktteamet selv hjelpe deg med å få ideen gjennomført.
 
-[//]: # (Card section skal ligge her)
-[//]: # (Innhold til Porteføljesaker card: "Når du trenger forankring hos ledelsen og ideen tar 6+ måneder å gjennomføre")
-[//]: # (Innhold til Produktgruppesaker card: "Når ideen må løses på tvers av flere team uten ekstra midler og ressurser")
-[//]: # (Innhold til Støtteordninger card: "Medfinansiering og Stimulab er gode alternativer til finansiering" - link til https://www.digdir.no/finansiering/finansiering/702)
-
+{{<sibling-pages>}}
 
 ## Opprett en issue i teamet sin backlog
 Hvem som helst kan komme med innspill og ønsker til teamene. Dette gjør du ved å opprette en ny issue i Github (du trenger en [github bruker](https://github.com/signup)).  
@@ -29,8 +25,7 @@ Hvis du er usikker på hvilket team du bør ta kontakt med så kan du spør i **
 
 ## Følg fremgangen
 
-Etter at du har opprettet issuen kan du trykke på subscribe nede til høyre (i github) for å bli varslet når noe skjer (se bilde under til venstre). Det kan også være kjekt å ta vare på tallet bak tittelen. Dette er en unik id for issuen din som du kan henvise til senere (se bilde under til høyre).  
+Etter at du har opprettet issuen så vil du [automatisk bli varslet](https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications#choosing-your-notification-settings) når noe skjer.
+Det kan også være kjekt å ta vare på tallet bak tittelen. Dette er en unik id for issuen din innenfor den aktuelle backloggen som du kan henvise til senere.  
 
-![Et bilde som viser subscribe funksjonen i github og hvor det går an å finne den unike IDen til issuet](/images/folg-fremgangen-github.png).  
-
-[Gå til implementering](https://baksia.digdir.no/produktutviklingsmodell/flyt#implementering)
+[Gå til implementering](../../flyt#implementering)


### PR DESCRIPTION
Updated content on the team-cases page according to V1 wireframes.

Before this pull request is merged, @altinnadmin needs to help to shift the order of the card section according to the placement specified in the comments in the .md file of this pull request.