### PR TITLE
Add content to portfolio-cases page according to V1 wireframes

### DIFF
--- a/content/produktutviklingsmodell/flyt/portfolio/_index.md
+++ b/content/produktutviklingsmodell/flyt/portfolio/_index.md
@@ -43,4 +43,4 @@ Etter å ha vært gjennom konsept- og planleggingsfasen har du fått beskrevet h
 
 Tiltaket fordeles deretter til produktgruppen, teamet / teamene eller arbeiedsgruppen som skal gjennomføre arbeidet.
 
-[Gå til implementering](/produktutviklingsmodell/flyt#implementering)
+[Gå til implementering](https://www.baksia.digdir.no/produktutviklingsmodell/flyt#implementering)

--- a/content/produktutviklingsmodell/flyt/portfolio/_index.md
+++ b/content/produktutviklingsmodell/flyt/portfolio/_index.md
@@ -1,20 +1,32 @@
 ---
 title: Porteføljesaker
-ingress: Denne siden forklarer porteføljen sin rolle i flyten for produktutvikling i Digdir.
-bannerimage: /images/portfolio-flow.webp
+ingress: Porteføljen sin rolle i flyten for produktutvikling i Digdir.
 weight: 10
 
 navigation_link:
   subtitle: Flyt av saker i porteføljen
 ---
 
-## Opprett tiltak i porteføljen
-Hvem som helst som ønsker å drive frem endring kan lage et nytt tiltak i porteføljen.
-Produktgruppeledere, design lead og sjefsarkitekt er representert i porteføljekontoret. De fungerer som rådgivere for porteføljestyrer, fronter tiltak fra produktgruppe-strategiene og ser etter muligheter for samarbeid på tvers.
 
-Porteføljen gir også innspill til Satsningsforslag og Virksomhetsplan på vegne av leverandørrollen i Digdir, og tar inn tiltak fra tildelingsbrev, Digdir strategi og andre førende dokumenter/OKRer.
+## Er porteføljen riktig sted for meg?
+Porteføljen er de sentrale tiltakene det må settes av midler og ressurser til (utover normal drift) for å realisere.  
+
+Dersom ideen din vil dra nytte av forankring fra ledelsen eller krever prioritet på tvers av flere team så kan porteføljen hjelpe deg med dette.
+
+
+[//]: # (Seksjonen med cards skal være her)
+[//]: # (Innhold til produktgruppesaker card: "Når ideen må løses på tvers av flere team uten ekstra midler og ressurser")
+[//]: # (Innhold til teamsaker card: "Når ideen din kan løses av ett team uten at det trengs ekstra midler og ressurser")
+[//]: # (Innhold til støtteordninger card: "Medfinansiering og Stimulab er gode alternativer for finansiering" - link til https://www.digdir.no/finansiering/finansiering/702)
+
+
+## Opprett tiltak i porteføljen
+Hvem som helst som ønsker å drive frem endring kan lage et nytt tiltak i porteføljen. Produktgruppeledere, Sjefsdesigner og Sjefsarkitekt er representert i porteføljekontoret. De fungerer som rådgivere for porteføljestyrer, fronter tiltak fra produktgruppe-strategiene og ser etter muligheter for samarbeid på tvers.  
+
+Porteføljen gir også innspill til Satsningsforslag og Virksomhetsplan på vegne av leverandørrollen i Digdir, og tar inn tiltak fra tildelingsbrev, Digdir strategi og andre førende dokumenter og OKRer.  
 
 [Gå til porteføljen](https://github.com/digdir/portfolio)
+
 
 ## Faser for et porteføljetiltak
 
@@ -25,17 +37,10 @@ Porteføljen gir også innspill til Satsningsforslag og Virksomhetsplan på vegn
 - Implementering
 - Utført
 
+
 ## Fordeling av tiltaket
-Etter å ha vært gjennom konsept- og planleggingsfasen har du fått beskrevet hvem som er ansvarlig for gjennomføring, hvilke teams som må involveres, hvilke ressurser og midler det er behov for med mer.
+Etter å ha vært gjennom konsept- og planleggingsfasen har du fått beskrevet hvem som er ansvarlig for gjennomføring, hvilke team som må involveres, hvilke ressurser og midler det er behov for med mer.  
 
-Tiltaket fordeles deretter til produktgruppen, teamet / teamene eller arbeidsgruppen som skal gjennomføre arbeidet.
+Tiltaket fordeles deretter til produktgruppen, teamet / teamene eller arbeiedsgruppen som skal gjennomføre arbeidet.
 
-## Implementering av tiltaket
-Når oppgaven har blitt fordelt ett eller flere teams lages det egne **epics** i **bakcklog** til teamet. Disse bruker teamet til å beskrive problemet og løsningen på et overordnet teknisk nivå for så å bryte oppgaven ned i mindre **issues** som de fordeler seg i mellom for å løse oppgaven.
-
-[Gå til team-oversiken](https://baksia.digdir.no/teams/)
-
-## Roadmap
-Porteføljen kan peke ned på elementer i roadmap, og elementene i roadmap peker ned på **epics** i teamene sine **baklogs** slik at vi får en rød tråd fra opprinnelse til leveranse. Etterhvert som alle relevante element i veikartet er levert settes porteføljetiltaket til **Utfør** og teamet går over til løpende måling og innsikt for å utbedre løsningen.
-
-[Gå til roadmap](https://github.com/orgs/digdir/projects/8)
+[Gå til implementering](/produktutviklingsmodell/flyt#implementering)

--- a/content/produktutviklingsmodell/flyt/portfolio/_index.md
+++ b/content/produktutviklingsmodell/flyt/portfolio/_index.md
@@ -13,11 +13,7 @@ Porteføljen er de sentrale tiltakene det må settes av midler og ressurser til 
 
 Dersom ideen din vil dra nytte av forankring fra ledelsen eller krever prioritet på tvers av flere team så kan porteføljen hjelpe deg med dette.
 
-
-[//]: # (Seksjonen med cards skal være her)
-[//]: # (Innhold til produktgruppesaker card: "Når ideen må løses på tvers av flere team uten ekstra midler og ressurser")
-[//]: # (Innhold til teamsaker card: "Når ideen din kan løses av ett team uten at det trengs ekstra midler og ressurser")
-[//]: # (Innhold til støtteordninger card: "Medfinansiering og Stimulab er gode alternativer for finansiering" - link til https://www.digdir.no/finansiering/finansiering/702)
+{{<sibling-pages>}}
 
 
 ## Opprett tiltak i porteføljen

--- a/layouts/shortcodes/sibling-pages.html
+++ b/layouts/shortcodes/sibling-pages.html
@@ -1,0 +1,37 @@
+{{ $currentPage := .Page }}
+{{ $siblings := $currentPage.Parent.Pages }}
+
+{{ if gt (len $siblings) 1 }}
+  <div class="component">
+    <div class="row gy-4">
+    {{ range where $siblings "Permalink" "ne" .Page.Permalink }}
+      <div class="col-sm-12 col-md-6 col-lg-4 col-xl-3">
+        <div class="navigation-card">
+          {{ if .Params.external_url }}
+            <a class="navigation-card__content nav-card-external__content" href="{{ .Params.external_url }}" target="_blank">
+              <h3 class="navigation-card__title navigation-card__title--small">
+                  <u>{{ .Title }}</u>
+              </h3>
+              <p class="navigation-card__desc navigation-card__desc--small">
+                  {{ .Params.navigation_link.text }}
+              </p>
+            </a>
+          {{ else}}
+            <a class="navigation-card__content" href="{{ .RelPermalink }}" style="background-color: #d2eafd">
+              <h3 class="navigation-card__title navigation-card__title--small">
+                  {{ .Title }}
+              </h3>
+              <h4 class="navigation_link_title">
+                  {{ .Params.navigation_link.title }}
+              </h4>
+              <p class="navigation_link_subtitle">
+                  {{ .Params.navigation_link.subtitle }}
+              </p>
+            </a>
+          {{ end }}
+        </div>
+      </div>
+    {{ end }}
+    </div>
+  </div>
+{{ end }}


### PR DESCRIPTION
Updated content on the portfolio-cases page to reflect V1 wireframes.

Before this pull request is merged, @altinnadmin needs to help shift the card section into the correct position as described in the comments of the .md file of this pull request.