### PR TITLE
Endret på økonomirapporteringer

### DIFF
--- a/content/brukeropplevelse-og-datadeling/rapportering/kolonne-3.md
+++ b/content/brukeropplevelse-og-datadeling/rapportering/kolonne-3.md
@@ -5,6 +5,4 @@ weight: 3
 ---
 
 {{< icon class="rep-li-start-icon" >}} [Trusselvurderinger i Digdir](https://digdir.sharepoint.com/SitePages/Trusselvurderinger.aspx?useTeamsAuth=true&OR=Teams-HL&CT=1729065449227&clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiI0OS8yNDA5MDEwMTQyMyIsIkhhc0ZlZGVyYXRlZFVzZXIiOmZhbHNlfQ%3D%3D)  
-{{< icon class="rep-li-start-icon" >}} [Økonomirapporter]()  
-{{< icon class="rep-li-start-icon" >}} [Tertialrapporter]()  
-{{< icon class="rep-li-start-icon" >}} [Årsrapporter]()
+{{< icon class="rep-li-start-icon" >}} [Virksomhetsplanlegging](https://digdir.sharepoint.com/sites/DigdirDGT/Delte%20dokumenter/Forms/AllItems.aspx?csf=1&web=1&e=ctZ9l4&OR=Teams%2DHL&CT=1729065874297&clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiI0OS8yNDA5MDEwMTQyMyIsIkhhc0ZlZGVyYXRlZFVzZXIiOmZhbHNlfQ%3D%3D&CID=d181b526%2Dc8d6%2D4553%2Da9ae%2D5b4ac154b5d1&FolderCTID=0x0120004EA8294F9ADB674FAAB36A65F01170FF&id=%2Fsites%2FDigdirDGT%2FDelte%20dokumenter%2FVirksomhetsstyring%20DGT%2FBudsjett%202024)  


### PR DESCRIPTION
Slått sammen Økonomirapportering, tertialrapportering og årsrapport - ny navn er Virksomhetsplanlegging.