### PR TITLE
Flyttet området for Risikostyring

### DIFF
--- a/content/produktleveransemodell/risikostyring/index.md
+++ b/content/produktleveransemodell/risikostyring/index.md
@@ -1,0 +1,23 @@
+---
+title: Risikostyring
+ingress: Risikostyring innebærer systematiske prosesser for å identifisere, vurdere og håndtere potensielle risikoer som kan påvirke BOD's evne til å oppnå sine mål. Effektiv risikostyring sikrer at BOD kan opprettholde kontinuitet og levere pålitelig tjenester.
+
+navigation_link:
+  subtitle: Hvordan vi jobber med risikostyring i BOD
+
+banner:
+  image:
+    src: /illustrations/illustration-03.png
+    alt: Illustrasjon av en person som sitter og leser en bok
+---
+
+Risikostyring
+- Team Koordinering har overordnet ansvaret for kapabiliteten risikostyring i BOD.
+- Arbeidet i team Koordinering består blant annet i å kontrollere at tiltakene i [Risikoregisteret](https://digdir.sharepoint.com/:x:/r/sites/RisikoBOD/Delte%20dokumenter/General/(UO)%20Risikoregister%20.xlsx?d=we2e6dba7fc5b4e58a231265f1b761856&csf=1&web=1&e=mRnSs4) blir fulgt opp av teamene.
+- I [Retningslinje for risikostyring](https://digdir.sharepoint.com/:b:/r/sites/RisikoBOD/Delte%20dokumenter/General/-UO--Retningslinje-for-risikostyring-v1.1.pdf?csf=1&web=1&e=1M9nX8) er det nærmere beskrevet hvordan avdelingen skal forholde seg til arbeidet med risiko.
+
+ROS-analyse
+- Team sikkerhet fasiliterer ROS-analyser innenfor personvern og sikkerhet.
+- Det er den enkelte produkteier (eventuelt prosjektleder) som har ansvar for at ROS-analyser gjennomføres innenfor sitt ansvarsområde.
+- Det er utarbeidet [prosess for hvordan ROS-analyser gjennomføres i BOD](https://digdir.sharepoint.com/:p:/r/sites/RisikoBOD/Delte%20dokumenter/General/Presentasjoner/Prosess%20for%20risikovurdering%20i%20BOD.pptx?d=w72e7267b32d04e7d983e8fe2b4eebac1&csf=1&web=1&e=cUNEn6).
+- Team koordinering kan kontaktes for å komme i gang med arbeidet. 


### PR DESCRIPTION
Ble bestemt at området for Risikostyring skulle flyttes fra Styringsinformasjon til PLM da dette området sier noe om hvordan vi jobber og er ikke statistikk/rapport el.