### PR TITLE
Remove group leader name from strategy document

### DIFF
--- a/content/brukeropplevelse-og-datadeling/seksjoner/strategi-og-forretningsutvikling.md
+++ b/content/brukeropplevelse-og-datadeling/seksjoner/strategi-og-forretningsutvikling.md
@@ -15,8 +15,6 @@ Medarbeiderne i seksjonen bidrar til at vi styrer produktutviklingen på en god 
 
 Seksjonsleder: Tor Arild Sunnevåg
 
-Gruppeleder produktledelse: Hanne Brun (fung)
-
 [Se ansatte i denne seksjonen](https://digdir.sharepoint.com/SitePages/Avdeling-Brukeropplevelse-og-datadeling.aspx)
 
 [Rollebeskrivelser](https://digdir.sharepoint.com/sites/DigdirDGT/Delte%20dokumenter/Forms/AllItems.aspx?id=%2Fsites%2FDigdirDGT%2FDelte%20dokumenter%2FRollebeskrivelser%2C%20nye%2C%20Arbeidsomr%C3%A5de%2FRollebeskrivelser%20BOD%2FRoller%20i%20seksjon%20Strategi%20%26%20Forretningsutvikling&viewid=66522cde%2D546b%2D4465%2Dbdf3%2Df2b757ea02ff&csf=1&web=1&e=1ITt9x&CID=8cd3868c%2De123%2D4f1c%2D9de9%2Dca20254b5006&FolderCTID=0x0120004EA8294F9ADB674FAAB36A65F01170FF).


### PR DESCRIPTION
Removed the name of the group leader for product management from the document.