### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hugo-verifications.yml
+++ b/.github/workflows/hugo-verifications.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/digdir/baksia/security/code-scanning/1](https://github.com/digdir/baksia/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to the minimum needed scope.  
Best fix here: define workflow-level permissions right after `on:` (or before `jobs:`), with `contents: read`. This preserves existing functionality (checkout and build/read operations continue to work) while documenting and enforcing least privilege across jobs.

**File to edit:** `.github/workflows/hugo-verifications.yml`  
**Change:** Insert:

```yml
permissions:
  contents: read
```

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
